### PR TITLE
Version 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### [0.2.2](https://github.com/speelbarrow/spLauncher.nvim/tree/v0.2.2)
+- Add call to `nvim_win_close` when `window.persist` is off ([e712684](
+https://github.com/speelbarrow/spLauncher.nvim/commit/e7126848219d2e49d0d3f8031203f0322e25145f))
+
 ### [0.2.1](https://github.com/speelbarrow/spLauncher.nvim/tree/v0.2.1)
 - Implement auto-scrolling and create an associated configuration parameter ([87b878a](
 https://github.com/speelbarrow/spLauncher.nvim/commit/87b878af8232934aa59fb5ce6afde3a08123e2b9))

--- a/doc/spLauncher.txt
+++ b/doc/spLauncher.txt
@@ -159,7 +159,9 @@ table/VimScript dictionary):
     spLauncher uses the Neovim |terminal| to execute command-line actions. By 
     default, the window will stay open after the program has exited until
     input is attempted. To override this (i.e. close the window immediately
-    after the program exits), set `persist` to `false`.
+    after the program exits), set `persist` to `false`. Note this this will
+    close ALL WINDOWS where the terminal buffer is open.
+
 
   - `position` (default: `"below"`)
     Defines which area of the screen should hold the new

--- a/lua/spLauncher/init.lua
+++ b/lua/spLauncher/init.lua
@@ -134,9 +134,12 @@ function M.direct_spLaunch(command, config)
     vim.api.nvim_create_autocmd("TermClose", {
       buffer = term_buf,
       once = true,
-      callback = function()
-        vim.schedule_wrap(vim.api.nvim_buf_delete)(term_buf, {})
-      end,
+      callback = vim.schedule_wrap(function()
+        for _, win in ipairs(vim.fn.win_findbuf(term_buf)) do
+          vim.api.nvim_win_close(win, false)
+        end
+        vim.api.nvim_buf_delete(term_buf, {})
+      end),
     })
   end
 

--- a/lua/spLauncher/types.lua
+++ b/lua/spLauncher/types.lua
@@ -40,7 +40,7 @@
 ---@field persist? boolean Default: `true`
 --- spLauncher uses the Neovim terminal to execute command-line actions. By default, the window will stay open after the
 --- program has exited until input is attempted. To override this (i.e. close the window immediately after the program
---- exits), set `persist` to `false`.
+--- exits), set `persist` to `false`. Note this this will close ALL WINDOWS where the terminal buffer is open.
 ---@field position? "below" | "above" | "left" | "right" Default: `"below"`
 --- Defines which area of the screen should hold the new window when spLauncher opens a terminal. `"above"` and
 --- `"below"` will result in horizontal splits, and `"left"` and `"right"` result in vertical splits. See


### PR DESCRIPTION
- Add call to `nvim_win_close` when `window.persist` is off ([e712684](
https://github.com/speelbarrow/spLauncher.nvim/commit/e7126848219d2e49d0d3f8031203f0322e25145f))
