### PR TITLE
Version 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### [0.3.0](https://github.com/speelbarrow/spLauncher.nvim/tree/v0.3.0)
+- Only call `nvim_win_close` when `window.persist = "force"`, otherwise just delete the buffer as done before v0.2.2
+([c9c87b7](https://github.com/speelbarrow/spLauncher.nvim/commit/c9c87b7cdfe51a1351400413769c611ed701a485))
+
 ### [0.2.2](https://github.com/speelbarrow/spLauncher.nvim/tree/v0.2.2)
 - Add call to `nvim_win_close` when `window.persist` is off ([e712684](
 https://github.com/speelbarrow/spLauncher.nvim/commit/e7126848219d2e49d0d3f8031203f0322e25145f))
@@ -14,7 +18,6 @@ https://github.com/speelbarrow/spLauncher.nvim/commit/9d21203f95d9a1065faa18d607
 - Fix project URL in README.md ([08952bd](
 https://github.com/speelbarrow/spLauncher.nvim/commit/08952bd39ae91f3df444a3d8f1f121ebacfa35ea)) 
 - Minor documentation updates
-
 
 ### [0.1.0](https://github.com/speelbarrow/spLauncher.nvim/tree/v0.1.0)
 - Initial release

--- a/doc/spLauncher.txt
+++ b/doc/spLauncher.txt
@@ -156,12 +156,13 @@ table/VimScript dictionary):
     behaviors.
 
   - `persist` (default: `true`)
-    spLauncher uses the Neovim |terminal| to execute command-line actions. By 
-    default, the window will stay open after the program has exited until
-    input is attempted. To override this (i.e. close the window immediately
-    after the program exits), set `persist` to `false`. Note this this will
-    close ALL WINDOWS where the terminal buffer is open.
-
+    spLauncher uses the Neovim |terminal| to execute command-line actions. By
+    default, the window will stay open after the program has exited until 
+    input is attempted (this is the default behaviour of the Neovim terminal).
+    There are two available override options: set this field to `false` and 
+    the *buffer* will close when the program exits, or set the value to
+    `"force"` and ALL windows displaying the buffer will close when the
+    program exits.
 
   - `position` (default: `"below"`)
     Defines which area of the screen should hold the new

--- a/lua/spLauncher/init.lua
+++ b/lua/spLauncher/init.lua
@@ -129,8 +129,8 @@ function M.direct_spLaunch(command, config)
     end
   end
 
-  -- Configure auto-closing when `config.window.persist` is false or if `silent` is on (i.e. the window is not open)
-  if (not config.window.persist) or config.silent then
+  if config.window.persist == "force" then
+    -- Configure auto-closing when `config.window.persist` is "force" (closes windows instead of buffers)
     vim.api.nvim_create_autocmd("TermClose", {
       buffer = term_buf,
       once = true,
@@ -140,6 +140,15 @@ function M.direct_spLaunch(command, config)
         end
         vim.api.nvim_buf_delete(term_buf, {})
       end),
+    })
+  elseif not config.window.persist or config.silent then
+    -- Configure auto-closing when `config.window.persist` is false or if `silent` is on (i.e. the window is not open)
+    vim.api.nvim_create_autocmd("TermClose", {
+      buffer = term_buf,
+      once = true,
+      callback = function()
+        vim.schedule_wrap(vim.api.nvim_buf_delete)(term_buf, {})
+      end,
     })
   end
 

--- a/lua/spLauncher/types.lua
+++ b/lua/spLauncher/types.lua
@@ -37,10 +37,11 @@
 ---@field focus? boolean | "insert" Default: `true`
 --- When `true`, moves the focus to the terminal window upon opening. When set to `"insert"`, moves the focus to the
 --- terminal window AND enters 'Insert' mode upon opening. Set to `false` to disable both of these behaviors.
----@field persist? boolean Default: `true`
+---@field persist? boolean | "force" Default: `true`
 --- spLauncher uses the Neovim terminal to execute command-line actions. By default, the window will stay open after the
---- program has exited until input is attempted. To override this (i.e. close the window immediately after the program
---- exits), set `persist` to `false`. Note this this will close ALL WINDOWS where the terminal buffer is open.
+--- program has exited until input is attempted. There are two available override options: set this field to `false` and
+--- the *buffer* will close when the program exits, or set the `window.persist` field to `"force"` and ALL windows
+--- displaying the buffer will close when the program exits.
 ---@field position? "below" | "above" | "left" | "right" Default: `"below"`
 --- Defines which area of the screen should hold the new window when spLauncher opens a terminal. `"above"` and
 --- `"below"` will result in horizontal splits, and `"left"` and `"right"` result in vertical splits. See


### PR DESCRIPTION
- Only call `nvim_win_close` when `window.persist = "force"`, otherwise just delete the buffer as done before v0.2.2
([c9c87b7](https://github.com/speelbarrow/spLauncher.nvim/commit/c9c87b7cdfe51a1351400413769c611ed701a485))
